### PR TITLE
1.0 issue 240

### DIFF
--- a/Resources/views/Knowledgebase/ticketList.html.twig
+++ b/Resources/views/Knowledgebase/ticketList.html.twig
@@ -152,7 +152,7 @@
                     <% } else { %>
                         <img class="uv-table-agent" src="{{ asset(default_agent_image_path) }}" alt=""/>
                     <% } %>
-                    <%- agent.name %>
+                    <%- agent.firstName +' '+(agent.lastName == null ?'':agent.lastName) %>
                 <% } else { %>
                     {{ 'Unassigned'|trans }}
                 <% } %>


### PR DESCRIPTION
#240 (https://github.com/uvdesk/core-framework/issues/240)
Another instance of agent's name displaying as blank if the last name of the agent is saved as null in the database. This issue is a core-framework issue, but also persists in the support-center-bundle.