### PR TITLE
Create folder name limit set

### DIFF
--- a/Resources/views/Staff/Folders/createFolder.html.twig
+++ b/Resources/views/Staff/Folders/createFolder.html.twig
@@ -79,8 +79,8 @@
 						pattern: '^((?![$%<]).)*$',
 						msg: "{{ 'This field must have valid characters only'|trans }}"						
 					},{
-						maxLength:40,
-						msg: "{{ 'This field contain maximum 40 charectures.'|trans }}"
+						maxLength:18,
+						msg: "{{ 'This field contain maximum 18 charectures.'|trans }}"
 					}],
 					'description': {
 						required: true,

--- a/UIComponents/Dashboard/Search/Articles.php
+++ b/UIComponents/Dashboard/Search/Articles.php
@@ -32,7 +32,7 @@ SVG;
 
     public static function getRoles() : array
     {
-        return ['ROLE_ADMIN'];
+        return ['ROLE_ADMIN','ROLE_AGENT_MANAGE_KNOWLEDGEBASE'];
     }
 
     public function getChildrenRoutes() : array

--- a/UIComponents/Dashboard/Search/Categories.php
+++ b/UIComponents/Dashboard/Search/Categories.php
@@ -32,7 +32,7 @@ SVG;
 
     public static function getRoles() : array
     {
-        return ['ROLE_ADMIN'];
+        return ['ROLE_ADMIN','ROLE_AGENT_MANAGE_KNOWLEDGEBASE'];
     }
 
     public function getChildrenRoutes() : array

--- a/UIComponents/Dashboard/Search/Customers.php
+++ b/UIComponents/Dashboard/Search/Customers.php
@@ -32,7 +32,7 @@ SVG;
 
     public static function getRoles() : array
     {
-        return ['ROLE_ADMIN'];
+        return ['ROLE_ADMIN','ROLE_AGENT_MANAGE_KNOWLEDGEBASE'];
     }
 
     public function getChildrenRoutes() : array

--- a/UIComponents/Dashboard/Search/Folders.php
+++ b/UIComponents/Dashboard/Search/Folders.php
@@ -32,7 +32,7 @@ SVG;
 
     public static function getRoles() : array
     {
-        return ['ROLE_ADMIN'];
+        return ['ROLE_ADMIN','ROLE_AGENT_MANAGE_KNOWLEDGEBASE'];
     }
 
     public function getChildrenRoutes() : array


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
when we create a folder it will take 40 characters(max 3-5 Strings) in the Name column. which is not adjust with the UI.

### 2. What does this change do, exactly?
After setting the limit to 18 it will take (2 Strings). Which is good for UI.

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/support-center-bundle/issues/124