### PR TITLE
No duplicate search option in the admin search & add agent privilages in this files

### DIFF
--- a/UIComponents/Dashboard/Search/Articles.php
+++ b/UIComponents/Dashboard/Search/Articles.php
@@ -32,7 +32,7 @@ SVG;
 
     public static function getRoles() : array
     {
-        return ['ROLE_ADMIN'];
+        return ['ROLE_ADMIN','ROLE_AGENT_MANAGE_KNOWLEDGEBASE'];
     }
 
     public function getChildrenRoutes() : array

--- a/UIComponents/Dashboard/Search/Categories.php
+++ b/UIComponents/Dashboard/Search/Categories.php
@@ -32,7 +32,7 @@ SVG;
 
     public static function getRoles() : array
     {
-        return ['ROLE_ADMIN'];
+        return ['ROLE_ADMIN','ROLE_AGENT_MANAGE_KNOWLEDGEBASE'];
     }
 
     public function getChildrenRoutes() : array

--- a/UIComponents/Dashboard/Search/Customers.php
+++ b/UIComponents/Dashboard/Search/Customers.php
@@ -32,7 +32,7 @@ SVG;
 
     public static function getRoles() : array
     {
-        return ['ROLE_ADMIN'];
+        return ['ROLE_ADMIN','ROLE_AGENT_MANAGE_CUSTOMER'];
     }
 
     public function getChildrenRoutes() : array

--- a/UIComponents/Dashboard/Search/Folders.php
+++ b/UIComponents/Dashboard/Search/Folders.php
@@ -32,7 +32,7 @@ SVG;
 
     public static function getRoles() : array
     {
-        return ['ROLE_ADMIN'];
+        return ['ROLE_ADMIN','ROLE_AGENT_MANAGE_KNOWLEDGEBASE'];
     }
 
     public function getChildrenRoutes() : array


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
when the agent got the privileges then after he will easily search them & No duplicate search option in the admin search as well.

### 2. What does this change do, exactly?
it will give agents the flexibility to search from the search bar easily the privileges.

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/core-framework/issues/349