### PR TITLE
fix for admin side attchment download

### DIFF
--- a/Resources/views/Knowledgebase/ticketView.html.twig
+++ b/Resources/views/Knowledgebase/ticketView.html.twig
@@ -515,7 +515,7 @@
                     <h4>{{ 'Uploaded Files'|trans }}</h4>
                     <div class="uv-ticket-uploads-strip uv-viewer-images">
                         <% _.each(attachments, function(file) { %>
-                            <a href="<%-file.downloadURL %>" target ="_blank" class="uv-ticket-uploads-brick uv-no-pointer-events" data-toggle="tooltip" title="<%- file.name %>">
+                            <a href="<%-file.downloadURL.replace("member","customer") %>" target ="_blank" class="uv-ticket-uploads-brick uv-no-pointer-events" data-toggle="tooltip" title="<%- file.name %>">
                                 <img src="<%-file.iconURL %>" class="uv-auto-pointer-events">
                             </a>
                         <% }) %>


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
From the customer, side the customer is not able to download the admin/agent attachment

### 2. What does this change do, exactly?
This will help customer to access the attachment of that ticket which admin or agent attachment

### 3. Please link to the relevant issues (if any).
