### PR TITLE
Feature added sorting ticket list on Last updated reply

### DIFF
--- a/Resources/views/Knowledgebase/ticketList.html.twig
+++ b/Resources/views/Knowledgebase/ticketList.html.twig
@@ -176,6 +176,15 @@
 
             <% } %>
         </li>
+		<li class="<% if(sort == 't.updatedAt') { %>uv-drop-list-active<% } %>">
+            <a href="#<% if(queryString != '') { %><%- queryString %>/<% } %><% if(page) { %>page/<%- page %><% } else { %>page/1<% } %>/sort/t.updatedAt/<% if(sort == 't.updatedAt') { %><% if(direction) { %>direction/<%- direction %><% } else { %>direction/desc<% } %><% } else { %>direction/asc<% } %>" data-field="t.updatedAt">
+                {{ 'Last Updated'|trans }}
+            </a>
+            <% if(sort == 't.updatedAt') { %>
+                <span class="uv-sorting <% if(direction == 'asc') { %> descend <% } else { %> ascend <% } %>"></span>
+
+            <% } %>
+        </li>
 	</script>
 	<!-- //Sorting Template -->
 


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
If a customer wants to see the latest replied ticket then this is only possible on the admin side.

### 2. What does this change do, exactly?
This will add an option for ticket listings to see the latest ticket replied by the agent or admin

### 3. Please link to the relevant issues (if any).
