### PR TITLE
update for announcement delete option

### DIFF
--- a/Controller/Announcement.php
+++ b/Controller/Announcement.php
@@ -95,11 +95,12 @@ Class Announcement extends Controller
         }
 
         $entityManager = $this->getDoctrine()->getManager();
-        $knowledgebaseAnnouncementId = $request->attributes->get('id');
+        $knowledgebaseAnnouncementId = $request->attributes->get('announcementId');
 
-        $knowledgebaseAnnouncement = $entityManager->getRepository(Announcement::class)->findOneBy([
-            'id' => $knowledgebaseAnnouncementId
-        ]);
+        $knowledgebaseAnnouncement = $this->getDoctrine()->getRepository('UVDeskSupportCenterBundle:Announcement')
+            ->findOneBy([
+                'id' => $request->attributes->get('announcementId')
+            ]);
 
         if ($knowledgebaseAnnouncement) {
             $entityManager->remove($knowledgebaseAnnouncement);

--- a/Resources/config/routes/private-agents.yaml
+++ b/Resources/config/routes/private-agents.yaml
@@ -153,5 +153,5 @@ helpdesk_member_knowledgebase_update_marketing_announcement:
 
 helpdesk_member_knowledgebase_remove_marketing_announcement_xhr:
     path:     /knowledgebase/announcement/remove/{announcementId}
-    controller: Webkul\UVDesk\SupportCenterBundle\Controller\Announcement::removeAnnouncement
+    controller: Webkul\UVDesk\SupportCenterBundle\Controller\Announcement::removeAnnouncementXHR
     defaults: { announcementId: 0 }

--- a/Resources/views/Staff/Announcement/listAnnouncement.html.twig
+++ b/Resources/views/Staff/Announcement/listAnnouncement.html.twig
@@ -138,7 +138,8 @@
 
 	<script type="text/javascript">
 		var path = "{{ path('helpdesk_member_knowledgebase_update_marketing_announcement', {'announcementId': 'replaceId' }) }}";
-
+        var deletePath = "{{ path('helpdesk_member_knowledgebase_remove_marketing_announcement_xhr', { 'announcementId': 'replaceId' }) }}";
+		
 		$(function () {
 			var globalMessageResponse = "";
 
@@ -208,7 +209,7 @@
 					app.appView.showLoader();
 					self = this;
 					this.model.destroy({
-						url : "{{ path('helpdesk_member_knowledgebase_remove_marketing_announcement_xhr') }}/"+this.model.get('announcementId'),
+						url: deletePath.replace('replaceId', this.model.get('id')),
 						success : function (model, response, options) {
 							app.appView.hideLoader();
 							globalMessageResponse = response;


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
Admin or agent is not able to delete Announcement once they are created.

### 2. What does this change do, exactly?
Now, they are able to delete the announcement, changes in id though URL & also function name updated.

### 3. Please link to the relevant issues (if any).
