### PR TITLE
(Knowledgebase) remove folder picture from assets

### DIFF
--- a/Controller/KnowledgebaseXHR.php
+++ b/Controller/KnowledgebaseXHR.php
@@ -7,6 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Webkul\UVDesk\CoreFrameworkBundle\Services\UserService;
 use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Filesystem\Filesystem as Fileservice;
 
 class KnowledgebaseXHR extends Controller
 {
@@ -89,6 +90,12 @@ class KnowledgebaseXHR extends Controller
             case "DELETE":
                 $solutionId = $request->attributes->get('folderId');
                 $solutionBase = $entityManager->getRepository('UVDeskSupportCenterBundle:Solutions')->find($solutionId);
+
+                $fileService = new Fileservice();
+
+                if ($solutionBase->getSolutionImage()) {
+                    $fileService->remove($this->container->getParameter('kernel.project_dir')."/public/".$solutionBase->getSolutionImage());
+                }
 
                 if($solutionBase){
                     $entityManager->getRepository('UVDeskSupportCenterBundle:Solutions')->removeEntryBySolution($solutionId);


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
The folder image is not deleted from the project directory as his image URL is deleted when deleting the folder(knowledgebase)

### 2. What does this change do, exactly?
Delete the Folder image from the project directory.

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/core-framework/issues/492