### PR TITLE
article it is not showing an error (200 keywords), sorting of articles "Active" & "Inactive", 250 keywords in the folder description

### DIFF
--- a/Resources/views/Staff/Articles/articleAddForm.html.twig
+++ b/Resources/views/Staff/Articles/articleAddForm.html.twig
@@ -82,7 +82,7 @@
 							<div class="uv-field-block">
 								<input name="metaTitle" class="uv-field" type="text" value="{{ article.metaTitle }}">
 							</div>
-							<span class="uv-field-info">{{"Title tags and meta descriptions are bits of HTML code in the header of a web page. They help search engines understand the content on a page. A pages title tag and meta description are usually shown whenever that page appears in search engine results"|trans}}</span>
+							<span class="uv-field-info">{{"Title tags and meta descriptions are bits of HTML code in the header of a web page. They help search engines understand the content on a page. A page's title tag and meta description are usually shown whenever that page appears in search engine results"|trans}}</span>
 						</div>
 						<!-- //Field -->
 
@@ -232,11 +232,19 @@
 						pattern: '^((?![$%<]).)*$',
 						msg: '{{ "This field must have valid characters only"|trans }}'
 					}],
+					'metaTitle':[{
+						maxLength:200,
+						msg: '{{ "This field contain mata title maximum 200 charecters only"|trans }}'
+					}],
+					'keywords':[{
+						maxLength:200,
+						msg: '{{ "This field contain keywords maximum 200 charecters only"|trans }}'
+					}],
 					'slug': function(val, attr, computed) {
 						var elSlug = $("[name=" + attr + "]");
 						var elSlugValue = '';
 						elSlug.val(elSlugValue = app.appView.convertToSlug(val))
-						
+					 
 						if(elSlugValue.trim() == ''){
 							return '{{ "This field is mandatory"|trans }}';
 						}

--- a/Resources/views/Staff/Articles/articleList.html.twig
+++ b/Resources/views/Staff/Articles/articleList.html.twig
@@ -98,8 +98,8 @@
 									<label>{{ 'Status'|trans }}</label>
 									<ul>
 										<li class="uv-drop-list-active"><a href="#">{{ 'All'|trans }}</a></li>
-										<li><a href="#" data-id="1">{{ 'Active'|trans }}</a></li>
-										<li><a href="#" data-id="0">{{ 'Disabled'|trans }}</a></li>
+										<li><a href="#" data-id="1">{{ 'Published'|trans }}</a></li>
+										<li><a href="#" data-id="0">{{ 'Draft'|trans }}</a></li>
 									</ul>
 								</div>
 							</div>

--- a/Resources/views/Staff/Folders/createFolder.html.twig
+++ b/Resources/views/Staff/Folders/createFolder.html.twig
@@ -82,10 +82,14 @@
 						maxLength:18,
 						msg: "{{ 'This field contain maximum 18 charectures.'|trans }}"
 					}],
-					'description': {
+					'description': [{
 						required: true,
 						msg: "{{ 'This field is mandatory'|trans }}"
-					}
+					},
+					{
+						maxLength:200,
+						msg: '{{ "This field contain maximum 250 charecters only"|trans }}'
+					}]
 				}
 			});
 

--- a/Resources/views/Staff/Folders/updateFolder.html.twig
+++ b/Resources/views/Staff/Folders/updateFolder.html.twig
@@ -83,10 +83,14 @@
 						maxLength:18,
 						msg: "{{ 'This field contain maximum 18 charectures.'|trans }}"
 					}],
-					'description': {
+					'description': [{
 						required: true,
 						msg: "{{ 'This field is mandatory'|trans }}"
-					}
+					},
+					{
+						maxLength:200,
+						msg: '{{ "This field contain maximum 250 charecters only"|trans }}'
+					}]
 				}
 			});
 


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?

1. When creating an article it is not showing an error (200 keywords).
2. On sorting of articles the name was given not appropriate "Active" & "Inactive".
3. If we added more than 250 keywords in the folder description then it shows an error.

### 2. What does this change do, exactly?

1. Add validation if inserted more than 200 keywords.
2. Added appropriate name on sorting Active => published & inActive => Draft.
3. Added validation on the description of 250 keywords

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/core-framework/issues/500
https://github.com/uvdesk/core-framework/issues/499
https://github.com/uvdesk/core-framework/issues/496