### PR TITLE
check slug in article, update limit of folder description

### DIFF
--- a/Controller/Article.php
+++ b/Controller/Article.php
@@ -246,6 +246,12 @@ class Article extends Controller
                                 $json['errors']['name'] = $this->translator->trans('Name length must not be greater than 200 !!');
                             }
 
+                            $slug = $entityManager->getRepository('UVDeskSupportCenterBundle:Article')->findOneBy(['slug' => $data['slug']]);
+                            
+                            if (!empty($slug)) {
+                                $json['errors']['slug'] = $this->translator->trans('Warning! Article slug is not available.');
+                            }
+
                             if (!$json['errors']) {
                                 unset($json['errors']);
                                 $article->setName($data['name']);

--- a/Resources/views/Staff/Folders/createFolder.html.twig
+++ b/Resources/views/Staff/Folders/createFolder.html.twig
@@ -87,7 +87,7 @@
 						msg: "{{ 'This field is mandatory'|trans }}"
 					},
 					{
-						maxLength:200,
+						maxLength:250,
 						msg: '{{ "This field contain maximum 250 charecters only"|trans }}'
 					}]
 				}

--- a/Resources/views/Staff/Folders/updateFolder.html.twig
+++ b/Resources/views/Staff/Folders/updateFolder.html.twig
@@ -88,7 +88,7 @@
 						msg: "{{ 'This field is mandatory'|trans }}"
 					},
 					{
-						maxLength:200,
+						maxLength:250,
 						msg: '{{ "This field contain maximum 250 charecters only"|trans }}'
 					}]
 				}


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
If the user creates an article then it takes & saves the same slug value. Slug value should not be the same.

### 2. What does this change do, exactly?
Now, first, we check if the given slug value is present in the database table then it shows a warning.

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/core-framework/issues/495