### PR TITLE
updates

### DIFF
--- a/Resources/views/Staff/Category/categoryForm.html.twig
+++ b/Resources/views/Staff/Category/categoryForm.html.twig
@@ -140,7 +140,7 @@
 						msg: "{{ 'This field must have valid characters only'|trans }}"
 					},{
 						maxLength:50,
-						msg: "{{ 'This field contain maximum 50 charectures.'|trans }}"
+						msg: "{{ 'This field contain maximum 50 characters.'|trans }}"
 					}],
 					'description': [{
 						required: true,
@@ -150,7 +150,7 @@
 						msg: "{{ 'This field must have valid characters only'|trans }}"
 					},{
 						maxLength:60,
-						msg: "{{ 'This field contain maximum 60 charectures.'|trans }}"
+						msg: "{{ 'This field contain maximum 60 characters.'|trans }}"
 					}],
                     'sortOrder': {
                         pattern: '^[0-9]*$',

--- a/Resources/views/Staff/Folders/createFolder.html.twig
+++ b/Resources/views/Staff/Folders/createFolder.html.twig
@@ -80,7 +80,7 @@
 						msg: "{{ 'This field must have valid characters only'|trans }}"						
 					},{
 						maxLength:18,
-						msg: "{{ 'This field contain maximum 18 charectures.'|trans }}"
+						msg: "{{ 'This field contain maximum 18 characters.'|trans }}"
 					}],
 					'description': [{
 						required: true,

--- a/Resources/views/Staff/Folders/updateFolder.html.twig
+++ b/Resources/views/Staff/Folders/updateFolder.html.twig
@@ -81,7 +81,7 @@
 					},
 					{
 						maxLength:18,
-						msg: "{{ 'This field contain maximum 18 charectures.'|trans }}"
+						msg: "{{ 'This field contain maximum 18 characters.'|trans }}"
 					}],
 					'description': [{
 						required: true,


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
1. When using description more than two words then showing description value in ticket view list when choosing ticket type.
2. In ticket type should take only characters not special characters
3. In ticket type code field should be shown limit warning message 
4. When using prepared responses with more than 100 words in name and description so validation is not working properly
5. In saved reply, more than 255 characters show an error instead of the warning message

### 2. What does this change do, exactly?
Fixed.

### 3. Please link to the relevant issues (if any).
https://github.com/uvdesk/core-framework/issues/525
https://github.com/uvdesk/core-framework/issues/526
https://github.com/uvdesk/core-framework/issues/527
https://github.com/uvdesk/core-framework/issues/528
https://github.com/uvdesk/core-framework/issues/529