### PR TITLE
add support role condition for customer profile update

### DIFF
--- a/Controller/Customer.php
+++ b/Controller/Customer.php
@@ -172,7 +172,7 @@ Class Customer extends AbstractController
                     $em->persist($user);
                     $em->flush();
 
-                    $userInstance = $em->getRepository('UVDeskCoreFrameworkBundle:UserInstance')->findOneBy(array('user' => $user->getId()));
+                    $userInstance = $em->getRepository('UVDeskCoreFrameworkBundle:UserInstance')->findOneBy(array('user' => $user->getId(), 'supportRole' => 4));
 
                     if (isset($dataFiles['profileImage'])) {
                         $previousImage = $userInstance->getProfileImagePath();


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
If a user has two accounts with the same email address & both accounts have different support role then it will change the profile for the admin role.

### 2. What does this change do, exactly?
Have added the support role condition on the profile update. So, that it will update the proper role account image

### 3. Please link to the relevant issues (if any).
Ticket [Support#27575]()