### PR TITLE
Remove old folder image from physical path if new folder image is uploaded

### DIFF
--- a/Controller/Folder.php
+++ b/Controller/Folder.php
@@ -144,6 +144,12 @@ class Folder extends AbstractController
             }
             $formData = $request->request->all();
             if (isset($solutionImage)) {
+                // Removing old image from physical path is new image uploaded
+                $fileService = new Fileservice();
+                if ($knowledgebaseFolder->getSolutionImage()) {
+                    $fileService->remove($this->getParameter('kernel.project_dir')."/public/".$knowledgebaseFolder->getSolutionImage());
+                }
+
                 $assetDetails = $this->fileSystem->getUploadManager()->uploadFile($solutionImage, 'knowledgebase');
                 $knowledgebaseFolder->setSolutionImage($assetDetails['path']);
             }

--- a/Controller/Folder.php
+++ b/Controller/Folder.php
@@ -12,6 +12,7 @@ use Webkul\UVDesk\CoreFrameworkBundle\Services\UserService;
 use Webkul\UVDesk\CoreFrameworkBundle\Services\FileUploadService;
 use Webkul\UVDesk\CoreFrameworkBundle\FileSystem\FileSystem;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\Component\Filesystem\Filesystem as Fileservice;
 
 class Folder extends AbstractController
 {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,10 @@
         "psr-4": { "Webkul\\UVDesk\\SupportCenterBundle\\": "" }
     },
     "extra": {
-        "uvdesk-package-extension": "Webkul\\UVDesk\\SupportCenterBundle\\Package\\Composer"
+        "uvdesk-package-extension": "Webkul\\UVDesk\\SupportCenterBundle\\Package\\Composer",
+        "branch-alias": {
+            "dev-master": "1.1.x-dev"
+        }
     },
     "minimum-stability": "stable"
 }


### PR DESCRIPTION
<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->
Removed old folder image from physical path if new image uploaded for folder.

### 1. Why is this change necessary?
Need to remove old folder image if updating current image for the folder.

### 2. What does this change do, exactly?
Will remove old folder image.

### 3. Please link to the relevant issues (if any).
#171 