### PR TITLE
Changes for tags, folders and categories warning messages

### DIFF
--- a/Resources/views/Staff/Articles/articleForm.html.twig
+++ b/Resources/views/Staff/Articles/articleForm.html.twig
@@ -925,7 +925,7 @@
 
 					if (e.which === 13 && text) {
 						if ((text.match(/^((?![!@#$%^&*()<_+]).)*$/))) {
-								if(text.length <= 35) {
+								if(text.length <= 20) {
 								let existed = false;
 								$('.uv-filtered-tags .uv-tag').each(function(key, el){
 									if($(el).text().toLowerCase() == text.toLowerCase())
@@ -977,7 +977,7 @@
 								}
 							} else {
 								inputElement.addClass('uv-field-error');
-								inputElement.parents('.uv-element-block').append("<span class='uv-field-message'>{{ 'Text length should be less than 35 charactors'|trans }}</span>");
+								inputElement.parents('.uv-element-block').append("<span class='uv-field-message'>{{ 'Text length should be less than 20 characters'|trans }}</span>");
 							}
 						} else {
 							inputElement.addClass('uv-field-error');

--- a/Resources/views/Staff/Category/categoryListBySolution.html.twig
+++ b/Resources/views/Staff/Category/categoryListBySolution.html.twig
@@ -590,10 +590,30 @@
 
             var FolderModel = Backbone.Model.extend({
 				validation: {
-					'name': {
+					'name': [{
                         required: true,
                         msg: '{{ "This field is mandatory"|trans }}'
-                    }
+                    }, 
+					{
+						pattern: '^((?![$%<]).)*$',
+						msg: "{{ 'This field must have valid characters only'|trans }}"						
+					},
+					{
+						maxLength:18,
+						msg: "{{ 'This field contain maximum 18 characters.'|trans }}"
+					}],
+					'description': [{
+						required: true,
+						msg: "{{ 'This field is mandatory'|trans }}"
+					}, 
+					{
+						pattern: '^((?![$%<]).)*$',
+						msg: "{{ 'This field must have valid characters only'|trans }}"						
+					},
+					{
+						maxLength:250,
+						msg: '{{ "This field contain maximum 250 charecters only"|trans }}'
+					}]
 				},
                 urlRoot : "{{ path('helpdesk_member_knowledgebase_update_folder_xhr') }}"
 			});

--- a/Resources/views/Staff/Folders/createFolder.html.twig
+++ b/Resources/views/Staff/Folders/createFolder.html.twig
@@ -87,6 +87,10 @@
 						msg: "{{ 'This field is mandatory'|trans }}"
 					},
 					{
+						pattern: '^((?![$%<]).)*$',
+						msg: "{{ 'This field must have valid characters only'|trans }}"						
+					},
+					{
 						maxLength:250,
 						msg: '{{ "This field contain maximum 250 charecters only"|trans }}'
 					}]


### PR DESCRIPTION
Changes for **tags, folders, and categories** warning messages


**Issues Description:**

**Issue 1:**  When **creating articles and adding tags** so here should be show the warning like this: 

**_Must be less than 20 characters_**

![image](https://user-images.githubusercontent.com/63539748/206101414-7ade9f88-7ff7-488a-959d-1508e2f2253a.png)



**Issue 2:**  In  the Folder option should be shown a warning for **does not take extra enter** in the **folder description field:**

**_This field must have valid characters only_**

![image](https://user-images.githubusercontent.com/63539748/206101265-d545bf9e-e5c5-4cfb-9ae7-ca5d385e1731.png)



**Issue 3:** If we edit a **Folder name with more than 18 characters from the category option** so there should be shown a warning like this:

**_This field contain maximum 18 characters._**

![image](https://user-images.githubusercontent.com/63539748/206101235-0c25597a-d383-40b3-9e53-5a96de0f7e12.png)


**Issues Link:**

https://github.com/uvdesk/support-center-bundle/issues/169

https://github.com/uvdesk/support-center-bundle/issues/196

