### PR TITLE
Now in the branding option if we hit the wrong URL, branding page shows the HTTP 400 NOT FOUND

### DIFF
--- a/Resources/config/routes/private-agents.yaml
+++ b/Resources/config/routes/private-agents.yaml
@@ -124,7 +124,7 @@ helpdesk_member_knowledgebase_related_article_xhr:
 
 # Members knowledgebase setting routing resources
 helpdesk_member_knowledgebase_theme:
-    path:     /branding/theme/{type}
+    path:     /branding/theme/
     controller: Webkul\UVDesk\SupportCenterBundle\Controller\Branding::theme
     defaults: { type: '' }
 

--- a/Resources/views/Templates/sidepanel.html.twig
+++ b/Resources/views/Templates/sidepanel.html.twig
@@ -29,7 +29,7 @@
             <h3>{{'Tags'|trans}}</h3>
             <div class="uv-tags">
                 {% for tag in articleTags %}
-                    <span><a href="{{path('helpdesk_knowledgebase_tag', {'tag': tag.id, 'name': tag.name})}}">{{tag.name}}</a></span>
+                    <span><a href="{{path('helpdesk_knowledgebase_tag', {'tag': tag.id, 'tag': tag.id})}}">{{tag.name}}</a></span>
                 {% endfor %}
             </div>
         </aside>


### PR DESCRIPTION
Please link to the relevant issues (if any).

https://github.com/uvdesk/core-framework/issues/595
