### PR TITLE
Fix exception when calling getAllCategories with Postgresql

### DIFF
--- a/Repository/Solutions.php
+++ b/Repository/Solutions.php
@@ -49,7 +49,7 @@ class Solutions extends \Doctrine\ORM\EntityRepository
         $categoryResponse = [];
         $categoryQB = $this->getEntityManager()->createQueryBuilder()->select('sc.id, sc.name, sc.description')
             ->from(SupportEntites\SolutionCategory::class, 'sc')
-            ->andWhere('sc.status = :status')->setParameter('status', true)
+            ->andWhere('sc.status = :status')->setParameter('status', 1)
             ->orderBy('sc.dateAdded', 'DESC');            
         
         return $categoryQB->getQuery()->getResult();


### PR DESCRIPTION
This is a purely "using this with Postgresql instead of Mysql on PHP 8.3 and then we hit type issues" problem

1. The status field is an integer in the entity
2. Doctrine tries to be clever and cast the boolean true passed into it to a "t" expecting the underlying field to be a boolean in the database as Postgresql has real boolean types
3. SQL go boom in a lovely exception

Easy fix, you're comparing integers here, use an integer not a boolean

<!--
Thank you for contributing to UVDesk! Please fill out this description template to help us to process your pull request.
-->

### 1. Why is this change necessary?
uvdesk will not run with postgresql without it


### 2. What does this change do, exactly?
fixes a logic and type issue


### 3. Please link to the relevant issues (if any).
